### PR TITLE
Add account statistics to start page

### DIFF
--- a/src/app/accounts/models/account-statistics.model.ts
+++ b/src/app/accounts/models/account-statistics.model.ts
@@ -1,0 +1,11 @@
+export interface AccountStatistics {
+
+  count: number;
+  totalCredit: number;
+  totalDebit: number;
+
+  avgCredit: number;
+  avgDebit: number;
+  avgBalance: number;
+
+}

--- a/src/app/common/components/start/start.component.html
+++ b/src/app/common/components/start/start.component.html
@@ -1,47 +1,117 @@
 <div class="start">
-  <div class="card">
-    <h2 class="card-header h5">Kunden</h2>
+  <div class="row mb-3 g-3">
+    <div class="offset-xl-3 col-xl-3 col-sm-6">
+      <div class="card h-100">
+        <h2 class="card-header h5">Kunden</h2>
 
-    <div class="card-body">
-      <h3 class="card-title h5 mb-4">
-        Verwalten Sie die Kunden der RAYBANK.
-      </h3>
+        <div class="card-body">
+          <h3 class="card-title h5 mb-4">
+            Verwalten Sie die Kunden der <em class="fw-light">RAYBANK</em>.
+          </h3>
 
-      <p class="card-text">
-        Alle Funktionen zum Verwalten der Kunden der <em class="fw-light">RAYBANK</em>
-        finden Sie hier.
-      </p>
-      <p class="card-text">
-        Hier können Sie bestehende Kundendaten einsehen, neue Kunden hinzufügen
-        und Kundendetails sicher anpassen.
-      </p>
+          <p class="card-text">
+            Alle Funktionen zum Verwalten der Kunden der <em class="fw-light">RAYBANK</em>
+            finden Sie hier.
+          </p>
+          <p class="card-text">
+            Hier können Sie bestehende Kundendaten einsehen, neue Kunden hinzufügen
+            und Kundendetails sicher anpassen.
+          </p>
+        </div>
 
-      <a routerLink="/clients" class="btn btn-secondary">
-        Kunden verwalten
-      </a>
+        <div class="card-footer text-center">
+          <a routerLink="/clients" class="btn btn-secondary">
+            Kunden verwalten
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-xl-3 col-sm-6">
+      <div class="card h-100">
+        <h2 class="card-header h5">Konten</h2>
+
+        <div class="card-body">
+          <h3 class="card-title h5 mb-4">
+            Verwalten Sie die Konten der <em class="fw-light">RAYBANK</em>.
+          </h3>
+
+          <p class="card-text">
+            Alle Funktionen zum Verwalten der Kundenkonten der <em class="fw-light">RAYBANK</em>
+            finden Sie hier.
+          </p>
+          <p class="card-text">
+            Hier können Sie bestehende Kundenkonten einsehen, neue Konten hinzufügen
+            und Kontodetails sicher anpassen.
+          </p>
+        </div>
+
+        <div class="card-footer text-center">
+          <a routerLink="/accounts" class="btn btn-secondary">
+            Konten verwalten
+          </a></div>
+      </div>
     </div>
   </div>
 
-  <div class="card">
-    <h2 class="card-header h5">Konten</h2>
+  <div class="row g-3">
+    <div class="offset-xl-3 col-xl-6 col-sm-12">
+      <div class="card h-100">
+        <h2 class="card-header h5">
+          Statistik
+        </h2>
 
-    <div class="card-body">
-      <h3 class="card-title h5 mb-4">
-        Verwalten Sie die Konten der RAYBANK.
-      </h3>
-
-      <p class="card-text">
-        Alle Funktionen zum Verwalten der Kundenkonten der <em class="fw-light">RAYBANK</em>
-        finden Sie hier.
-      </p>
-      <p class="card-text">
-        Hier können Sie bestehende Kundenkonten einsehen, neue Konten hinzufügen
-        und Kontodetails sicher anpassen.
-      </p>
-
-      <a routerLink="/accounts" class="btn btn-secondary">
-        Konten verwalten
-      </a>
+        <div class="card-body">
+          @let stats = (accountStats$ | async)!;
+          <ul class="list-group">
+            <li class="list-group-item">
+              <ng-template [ngTemplateOutlet]="statsLine"
+                           [ngTemplateOutletContext]="{ caption: 'Kunden', value: (clients$ | async)?.length ?? 0 }"> >
+              </ng-template>
+            </li>
+            <li class="list-group-item">
+              <ng-template [ngTemplateOutlet]="statsLine"
+                           [ngTemplateOutletContext]="{ caption: 'Konten', value: stats.count }"> >
+              </ng-template>
+            </li>
+            <li class="list-group-item">
+              <ng-template [ngTemplateOutlet]="statsLine"
+                           [ngTemplateOutletContext]="{ caption: 'Gesamt-Haben', value: stats.totalCredit | currency: 'EUR' }"> >
+              </ng-template>
+            </li>
+            <li class="list-group-item">
+              <ng-template [ngTemplateOutlet]="statsLine"
+                           [ngTemplateOutletContext]="{ caption: 'Gesamt-Soll', value: stats.totalDebit | currency: 'EUR' }"> >
+              </ng-template>
+            </li>
+            <li class="list-group-item">
+              <ng-template [ngTemplateOutlet]="statsLine"
+                           [ngTemplateOutletContext]="{ caption: '∅-Saldo', value: stats.avgBalance | currency: 'EUR' }"> >
+              </ng-template>
+            </li>
+            <li class="list-group-item">
+              <ng-template [ngTemplateOutlet]="statsLine"
+                           [ngTemplateOutletContext]="{ caption: '∅-Haben', value: stats.avgCredit | currency: 'EUR' }"> >
+              </ng-template>
+            </li>
+            <li class="list-group-item">
+              <ng-template [ngTemplateOutlet]="statsLine"
+                           [ngTemplateOutletContext]="{ caption: '∅-Soll', value: stats.avgDebit | currency: 'EUR' }"> >
+              </ng-template>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
   </div>
 </div>
+
+
+<ng-template #statsLine
+             let-caption="caption"
+             let-value="value">
+  <div class="hstack gap-2 justify-content-between">
+    <div class="stats-line-caption">{{ caption }}</div>
+    <div class="stats-line-value">{{ value }}</div>
+  </div>
+</ng-template>

--- a/src/app/common/components/start/start.component.ts
+++ b/src/app/common/components/start/start.component.ts
@@ -1,14 +1,32 @@
-import { Component } from "@angular/core";
+import { Component, inject, OnInit } from "@angular/core";
 import { RouterLink } from "@angular/router";
+import { ClientService } from "../../../clients/services/client.service";
+import { AsyncPipe, CurrencyPipe, NgTemplateOutlet } from "@angular/common";
+import { AccountsService } from "../../../accounts/services/accounts.service";
 
 
 @Component({
   selector: "app-start",
   imports: [
-    RouterLink
+    RouterLink,
+    AsyncPipe,
+    CurrencyPipe,
+    NgTemplateOutlet
   ],
   templateUrl: "./start.component.html"
 })
-export class StartComponent {
+export class StartComponent implements OnInit {
+
+  private readonly clientService = inject(ClientService);
+  private readonly accountService = inject(AccountsService);
+
+  protected clients$ = this.clientService.clients$;
+  protected accountStats$ = this.accountService.getAccountStatistics();
+
+
+  public ngOnInit() {
+    this.clientService.updateClients();
+    this.accountService.updateAccounts();
+  }
 
 }

--- a/src/app/styles/start.scss
+++ b/src/app/styles/start.scss
@@ -1,11 +1,13 @@
 .start {
-  display: flex;
-  gap: 2rem;
-  justify-content: center;
-
   padding-top: 5rem;
 
-  .card {
-    max-width: 32ch;
+  .stats-line {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: space-between;
+
+    &-value {
+      font-weight: 500;
+    }
   }
 }


### PR DESCRIPTION
### Summary
This pull request introduces an account statistics feature to the start page. It includes the following changes:
- Added `AccountStatistics` model and computation logic in the `AccountsService`.
- Displayed key statistics such as account count, total credit/debit, and averages on the start page.
- Enhanced styles and structure for improved layout and readability.
